### PR TITLE
fix: use Go 1.23.0 as minimum supported version in go.mod

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,3 +1,3 @@
 module darvaza.org/babu
 
-go 1.24.4
+go 1.23.0


### PR DESCRIPTION
## Summary
- Fixed go.mod to specify Go 1.23.0 instead of non-existent 1.24.4
- This ensures the CI matrix values (1.23 and 1.24) are respected
- Fixes golangci-lint version detection in the Makefile

## Background
The go.mod file was specifying `go 1.24.4` which doesn't exist yet. This caused Go's automatic toolchain management to download Go 1.24.4 even when the CI explicitly requested Go 1.23, leading to golangci-lint failures.

By specifying the minimum supported version (1.23.0) in go.mod, we allow the CI matrix to control which Go version is actually used for testing.

## Test plan
- [x] CI passes with both Go 1.23 and 1.24
- [x] golangci-lint runs successfully in both versions