### PR TITLE
fix: correct component naming from badu to babu

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -3,7 +3,6 @@
     "Apptly",
     "Babu",
     "bābu",
-    "badu",
     "darvaza",
     "GOPATH"
   ]

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,9 +10,9 @@ and this project adheres to [Semantic Versioning][semver].
 ### Added
 
 - Initial project scaffolding with three core binaries:
-  - `badu` - SSH client with Babu-specific features
-  - `badu-server` - SSH server with port-based client identification
-  - `badu-proxy` - Reverse SSH proxy for admin access to clients
+  - `babu` - SSH client with Babu-specific features
+  - `babu-server` - SSH server with port-based client identification
+  - `babu-proxy` - Reverse SSH proxy for admin access to clients
 - Build infrastructure (Makefile, version scripts, go.mod)
 - Development configuration (.editorconfig, revive linting)
 - CI/CD workflows (GitHub Actions build and Renovate)

--- a/README.md
+++ b/README.md
@@ -16,11 +16,11 @@ and centralised management.
 
 Babu provides three core components:
 
-1. **`badu-server`** - SSH server replacing OpenSSH with dual functionality:
+1. **`babu-server`** - SSH server replacing OpenSSH with dual functionality:
    - Virtual ports for device clients (no TCP binding)
    - Full shell access for administrators
-2. **`badu`** - Specialised SSH client with integrated service support
-3. **`badu-proxy`** - Tool for admin access to devices via virtual ports
+2. **`babu`** - Specialised SSH client with integrated service support
+3. **`babu-proxy`** - Tool for admin access to devices via virtual ports
 
 ## Key Features
 
@@ -32,7 +32,7 @@ Babu provides three core components:
 
 ## Components
 
-### `badu-server`
+### `babu-server`
 
 A complete SSH server implementation with innovative virtual port technology:
 
@@ -47,7 +47,7 @@ A complete SSH server implementation with innovative virtual port technology:
 - Manages client registration and re-keying
 - Detects key compromise through concurrent usage
 
-### `badu-proxy`
+### `babu-proxy`
 
 A reverse proxy tool that:
 
@@ -56,7 +56,7 @@ A reverse proxy tool that:
 - Creates port forwarding for client-side services
 - Integrates with SSH `ProxyCommand` for transparent access
 
-### `badu`
+### `babu`
 
 The intelligent SSH client that:
 
@@ -79,15 +79,15 @@ New clients can self-register using factory keys:
 
 ```bash
 # Install Babu
-go install darvaza.org/babu/cmd/badu@latest
-go install darvaza.org/babu/cmd/badu-server@latest
-go install darvaza.org/babu/cmd/badu-proxy@latest
+go install darvaza.org/babu/cmd/babu@latest
+go install darvaza.org/babu/cmd/babu-server@latest
+go install darvaza.org/babu/cmd/babu-proxy@latest
 
 # Start the server
-badu-server --config /etc/babu/server.yaml
+babu-server --config /etc/babu/server.yaml
 
 # Connect a client
-badu connect --server babu.example.com --port 30001
+babu connect --server babu.example.com --port 30001
 ```
 
 ## Documentation
@@ -140,8 +140,8 @@ Babu is released under the [MIT License][license-file].
 ## Support
 
 - **Documentation**: See the [docs/][docs] directory
-- **Issues**: [GitHub Issues][badu-issues]
-- **Discussions**: [GitHub Discussions][badu-discussions]
+- **Issues**: [GitHub Issues][babu-issues]
+- **Discussions**: [GitHub Discussions][babu-discussions]
 - **Security**: See [SECURITY.md][security]
 
 ## Acknowledgements
@@ -169,7 +169,7 @@ library and benefits from the Go community's work on SSH tooling.
 [license-file]: LICENSE.txt
 [security]: SECURITY.md
 
-[badu-issues]: https://github.com/darvaza-proxy/babu/issues
-[badu-discussions]: https://github.com/darvaza-proxy/babu/discussions
+[babu-issues]: https://github.com/darvaza-proxy/babu/issues
+[babu-discussions]: https://github.com/darvaza-proxy/babu/discussions
 
 [go-ssh]: https://pkg.go.dev/golang.org/x/crypto/ssh

--- a/cmd/babu-proxy/main.go
+++ b/cmd/babu-proxy/main.go
@@ -1,0 +1,4 @@
+// Package babu-proxy implements the babu ssh proxy
+package main
+
+func main() {}

--- a/cmd/babu-server/main.go
+++ b/cmd/babu-server/main.go
@@ -1,0 +1,4 @@
+// Package babu-server implements the babu ssh server
+package main
+
+func main() {}

--- a/cmd/babu/main.go
+++ b/cmd/babu/main.go
@@ -1,0 +1,4 @@
+// Package babu implements the babu ssh client
+package main
+
+func main() {}

--- a/cmd/badu-proxy/main.go
+++ b/cmd/badu-proxy/main.go
@@ -1,4 +1,0 @@
-// Package badu-proxy implements the badu ssh proxy
-package main
-
-func main() {}

--- a/cmd/badu-server/main.go
+++ b/cmd/badu-server/main.go
@@ -1,4 +1,0 @@
-// Package badu-server implements the badu ssh server
-package main
-
-func main() {}

--- a/cmd/badu/main.go
+++ b/cmd/badu/main.go
@@ -1,4 +1,0 @@
-// Package badu implements the badu ssh client
-package main
-
-func main() {}

--- a/docs/README.md
+++ b/docs/README.md
@@ -17,7 +17,7 @@ deploy, and operate Babu in your environment.
 - [Design Decisions](architecture/design-decisions.md) - Key design choices
 - [Port Architecture](architecture/port-architecture.md) - Logical port model
 - [Client Model](architecture/client-model.md) - Client organization
-- [Badu Proxy](architecture/badu-proxy.md) - Proxy component architecture
+- [Babu Proxy](architecture/babu-proxy.md) - Proxy component architecture
 - [Scaling](architecture/scaling.md) - Horizontal scaling design
 - [Security](architecture/security.md) - Security architecture
 
@@ -44,19 +44,19 @@ deploy, and operate Babu in your environment.
 
 ## Quick Links
 
-- [GitHub Repository][badu-git]
-- [Issue Tracker][badu-issues]
-- [Releases][badu-releases]
+- [GitHub Repository][babu-git]
+- [Issue Tracker][babu-issues]
+- [Releases][babu-releases]
 
 ## Getting Help
 
 - Check the documentation
 - Search existing issues
 - Ask in discussions
-- Contact: [oss@apptly.co][badu-contact]
+- Contact: [oss@apptly.co][babu-contact]
 
 <!-- references -->
-[badu-contact]: mailto:oss@apptly.co
-[badu-git]: https://github.com/darvaza-proxy/badu
-[badu-issues]: https://github.com/darvaza-proxy/badu/issues
-[badu-releases]: https://github.com/darvaza-proxy/badu/releases
+[babu-contact]: mailto:oss@apptly.co
+[babu-git]: https://github.com/darvaza-proxy/babu
+[babu-issues]: https://github.com/darvaza-proxy/babu/issues
+[babu-releases]: https://github.com/darvaza-proxy/babu/releases

--- a/docs/architecture/babu-proxy.md
+++ b/docs/architecture/babu-proxy.md
@@ -1,9 +1,9 @@
-# Badu-Proxy Design
+# Babu-Proxy Design
 
 ## Overview
 
-`badu-proxy` serves as the unified interface for accessing devices through
-badu-server's virtual ports. It provides both ProxyCommand functionality for
+`babu-proxy` serves as the unified interface for accessing devices through
+babu-server's virtual ports. It provides both ProxyCommand functionality for
 transparent SSH access and a CLI for system management.
 
 ## Dual Purpose Design
@@ -14,14 +14,14 @@ Used transparently by SSH tools to establish connections:
 
 ```bash
 # Direct usage
-ssh -o 'ProxyCommand badu-proxy connect %h' rogueN
+ssh -o 'ProxyCommand babu-proxy connect %h' rogueN
 
 # Via .ssh/config
 Host rogue*
-    ProxyCommand badu-proxy connect %h
+    ProxyCommand babu-proxy connect %h
 
 Host client-*
-    ProxyCommand badu-proxy connect %h
+    ProxyCommand babu-proxy connect %h
 ```
 
 Once configured, all SSH-based tools work seamlessly:
@@ -39,23 +39,23 @@ Administrative interface for querying and managing the system:
 
 ```bash
 # List clients
-badu-proxy list                     # All clients
-badu-proxy list --status=online     # Connected clients
-badu-proxy list --status=dropped    # Recently disconnected
-badu-proxy list --compromised       # Clients with compromised keys
+babu-proxy list                     # All clients
+babu-proxy list --status=online     # Connected clients
+babu-proxy list --status=dropped    # Recently disconnected
+babu-proxy list --compromised       # Clients with compromised keys
 
 # Client information
-badu-proxy show rogueN              # Detailed client info
-badu-proxy status rogueN            # Connection status
-badu-proxy history rogueN           # Connection history
+babu-proxy show rogueN              # Detailed client info
+babu-proxy status rogueN            # Connection status
+babu-proxy history rogueN           # Connection history
 
 # Registration operations
-badu-proxy register rogueN --crm-id=12345 --hostname=client-name
-badu-proxy rekey client-name        # Initiate rekeying
+babu-proxy register rogueN --crm-id=12345 --hostname=client-name
+babu-proxy rekey client-name        # Initiate rekeying
 
 # Compromise management
-badu-proxy list --key=<keyfingerprint>  # Find all clients using a key
-badu-proxy quarantine --key=<keyfingerprint>  # Mark key as compromised
+babu-proxy list --key=<keyfingerprint>  # Find all clients using a key
+babu-proxy quarantine --key=<keyfingerprint>  # Mark key as compromised
 ```
 
 ## Architecture
@@ -67,14 +67,14 @@ graph TB
         Admin[Admin Commands]
     end
 
-    subgraph "Badu Proxy"
+    subgraph "Babu Proxy"
         CLI[CLI Parser]
         Resolver[Client Resolver]
         ConnProxy[Connection Proxy]
     end
 
     subgraph "Backend"
-        BaduServer[badu-server]
+        BabuServer[babu-server]
         VirtualPorts[Virtual Port Registry]
         ConfigStore[(Git Config)]
     end
@@ -86,8 +86,8 @@ graph TB
     ConnProxy --> Resolver
 
     Resolver --> ConfigStore
-    Resolver --> BaduServer
-    BaduServer --> VirtualPorts
+    Resolver --> BabuServer
+    BabuServer --> VirtualPorts
 ```
 
 ## Key Features
@@ -97,13 +97,13 @@ graph TB
 The proxy resolves client identities:
 
 1. Check Git configuration for client details
-2. Lookup virtual port in badu-server
+2. Lookup virtual port in babu-server
 3. Establish connection through virtual port
 4. Handle connection multiplexing
 
 ### Connection Telemetry
 
-`badu-server` provides rich telemetry that `badu-proxy` exposes:
+`babu-server` provides rich telemetry that `babu-proxy` exposes:
 
 - **Connect events**: timestamp, source IP, auth method
 - **Disconnect events**: timestamp, duration, reason
@@ -121,16 +121,16 @@ When a key is used by multiple clients:
 
 ```bash
 # Compromise workflow
-badu-proxy list --compromised           # List all compromised clients
-badu-proxy show --key=<fingerprint>     # Show all clients using key
-badu-proxy rekey original-client        # Generate new key for legitimate client
-badu-proxy register clone-1 --crm-id=X  # Re-register legitimate clones
-badu-proxy revoke --key=<fingerprint>   # Block compromised key after recovery
+babu-proxy list --compromised           # List all compromised clients
+babu-proxy show --key=<fingerprint>     # Show all clients using key
+babu-proxy rekey original-client        # Generate new key for legitimate client
+babu-proxy register clone-1 --crm-id=X  # Re-register legitimate clones
+babu-proxy revoke --key=<fingerprint>   # Block compromised key after recovery
 ```
 
 ## Client Configuration
 
-`badu-proxy` uses Git-backed configuration for client management:
+`babu-proxy` uses Git-backed configuration for client management:
 
 ```yaml
 # Client configuration
@@ -146,7 +146,7 @@ clients:
     services: ["ntp", "dns", "socks5"]
 ```
 
-All client connections are handled through badu-server's virtual port system.
+All client connections are handled through babu-server's virtual port system.
 
 ## Implementation Considerations
 
@@ -183,7 +183,7 @@ When detecting compromised keys:
 
 ```bash
 # Generate .ssh/config entries
-badu-proxy generate-config > ~/.ssh/config.d/babu
+babu-proxy generate-config > ~/.ssh/config.d/babu
 
 # Include in main SSH config
 echo "Include ~/.ssh/config.d/*" >> ~/.ssh/config
@@ -193,12 +193,12 @@ echo "Include ~/.ssh/config.d/*" >> ~/.ssh/config
 
 ```bash
 # Check before operations
-if badu-proxy status "$CLIENT" | grep -q online; then
+if babu-proxy status "$CLIENT" | grep -q online; then
     ssh "$CLIENT" "command"
 fi
 
 # Bulk operations
-badu-proxy list --status=online | while read client; do
+babu-proxy list --status=online | while read client; do
     ssh "$client" "update-command"
 done
 ```


### PR DESCRIPTION
## Summary

- Correct component naming from `badu` to `babu` throughout the codebase
- Rename cmd directories to match agreed naming convention
- Update all documentation references

## Changes

- Renamed `cmd/badu*` directories to `cmd/babu*`
- Updated component names in README.md and documentation
- Renamed `badu-proxy.md` to `babu-proxy.md`
- Fixed all references to use consistent naming

This ensures the project uses the correct component names as agreed:
- `babu` - client application
- `babu-server` - SSH server with virtual port support
- `babu-proxy` - administrative access tool

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Introduced initial stubs for the `babu`, `babu-server`, and `babu-proxy` command-line applications.

* **Documentation**
  * Standardized naming throughout all documentation from "badu" to "babu" for all core components and references.
  * Updated command examples, section headers, and URLs to reflect the corrected "babu" naming.
  * Corrected changelog entries to match the new naming convention.

* **Chores**
  * Removed obsolete references to "badu" in configuration and spelling settings.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->